### PR TITLE
More xmas stuff

### DIFF
--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -47,6 +47,13 @@ extern PlayState* gPlayState;
 #include "objects/object_gjyo_objects/object_gjyo_objects.h"
 #include "textures/nintendo_rogo_static/nintendo_rogo_static.h"
 #include "objects/object_gi_rabit_mask/object_gi_rabit_mask.h"
+#include "objects/object_wood02/object_wood02.h"
+#include "scenes/overworld/spot00/spot00_room_0.h"
+#include "scenes/overworld/spot04/spot04_room_0.h"
+#include "scenes/overworld/spot04/spot04_room_1.h"
+#include "scenes/overworld/spot20/spot20_room_0.h"
+#include "scenes/overworld/spot03/spot03_room_0.h"
+#include "scenes/overworld/spot15/spot15_room_0.h"
 void ResourceMgr_PatchGfxByName(const char* path, const char* patchName, int index, Gfx instruction);
 void ResourceMgr_PatchGfxCopyCommandByName(const char* path, const char* patchName, int destinationIndex, int sourceIndex);
 void ResourceMgr_UnpatchGfxByName(const char* path, const char* patchName);
@@ -441,6 +448,24 @@ void CosmeticsUpdateTick() {
     5. GFX Command: The GFX command you want to insert
 */
 void ApplyOrResetCustomGfxPatches(bool manualChange) {
+    if (manualChange) {
+        PATCH_GFX(object_wood02_DL_007968,                        "Tree1",                    "gLetItSnow",                        17, gsDPSetPrimColor(0, 0, 255, 255, 255, 255));
+        PATCH_GFX(object_wood02_DL_000090,                        "Tree2",                    "gLetItSnow",                        17, gsDPSetPrimColor(0, 0, 200, 255, 255, 255));
+        PATCH_GFX(object_wood02_DL_000340,                        "Tree3",                    "gLetItSnow",                        17, gsDPSetPrimColor(0, 0, 255, 255, 255, 255));
+        PATCH_GFX(object_wood02_DL_000340,                        "Tree4",                    "gLetItSnow",                        24, gsDPSetPrimColor(0, 0, 255, 255, 255, 255));
+        PATCH_GFX(spot00_room_0DL_0139A8,                         "Path1",                    "gLetItSnow",                        23, gsDPSetPrimColor(0, 0, 100, 150, 255, 60));
+        PATCH_GFX(spot00_room_0DL_013250,                         "Path2",                    "gLetItSnow",                        23, gsDPSetPrimColor(0, 0, 100, 150, 255, 60));
+        PATCH_GFX(spot00_room_0DL_0143C8,                         "Path3",                    "gLetItSnow",                        23, gsDPSetPrimColor(0, 0, 100, 150, 255, 60));
+        PATCH_GFX(spot04_room_0DL_018048,                         "Path4",                    "gLetItSnow",                        24, gsDPSetPrimColor(0, 0, 100, 150, 255, 60));
+        PATCH_GFX(spot04_room_1DL_007810,                         "Path5",                    "gLetItSnow",                        24, gsDPSetPrimColor(0, 0, 100, 150, 255, 60));
+        PATCH_GFX(spot20_room_0DL_0062D0,                         "Path6",                    "gLetItSnow",                        23, gsDPSetPrimColor(0, 0, 200, 230, 255, 30));
+        PATCH_GFX(spot20_room_0DL_004460,                         "Path8",                    "gLetItSnow",                        31, gsDPSetPrimColor(0, 0, 200, 230, 255, 30));
+        PATCH_GFX(spot20_room_0DL_004460,                         "Path9",                    "gLetItSnow",                       118, gsDPSetPrimColor(0, 0, 200, 230, 255, 30));
+        PATCH_GFX(spot20_room_0DL_0065E8,                         "Path10",                   "gLetItSnow",                        24, gsDPSetPrimColor(0, 0, 200, 230, 255, 30));
+        PATCH_GFX(spot03_room_0DL_00C4B0,                         "Path11",                   "gLetItSnow",                        23, gsDPSetPrimColor(0, 0, 200, 230, 255, 30));
+        PATCH_GFX(spot15_room_0DL_00C748,                         "Path12",                   "gLetItSnow",                        23, gsDPSetPrimColor(0, 0, 200, 230, 255, 30));
+    }
+
     static CosmeticOption& linkGoronTunic = cosmeticOptions.at("Link_GoronTunic");
     if (manualChange || CVarGetInteger(linkGoronTunic.rainbowCvar, 0)) {
         static Color_RGBA8 defaultColor = {linkGoronTunic.defaultColor.x, linkGoronTunic.defaultColor.y, linkGoronTunic.defaultColor.z, linkGoronTunic.defaultColor.w};

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1062,6 +1062,13 @@ extern "C" void InitOTR() {
     tm *tm_now = localtime(&now);
     
     CVarRegisterInteger("gLetItSnow", 1);
+    CVarRegisterInteger("gAltAssets", 1);
+    CVarRegisterInteger("gCosmetics.Hud_AButton.Changed", 1);
+    CVarRegisterColor("gCosmetics.Hud_AButton.Value", Color_RGBA8{ 255, 255, 255, 255 });
+    CVarRegisterInteger("gCosmetics.Hud_BButton.Changed", 1);
+    CVarRegisterColor("gCosmetics.Hud_BButton.Value", Color_RGBA8{ 255, 255, 255, 255 });
+    CVarRegisterInteger("gCosmetics.Hud_CButtons.Changed", 1);
+    CVarRegisterColor("gCosmetics.Hud_CButtons.Value", Color_RGBA8{ 255, 255, 255, 255 });
     CVarRegisterInteger("gCosmetics.Consumable_Hearts.Changed", 1);
     CVarRegisterColor("gCosmetics.Consumable_Hearts.Value", Color_RGBA8{ 255, 158, 0, 255 });
     CVarRegisterInteger("gCosmetics.Consumable_Magic.Changed", 1);

--- a/soh/src/code/z_kankyo.c
+++ b/soh/src/code/z_kankyo.c
@@ -2289,17 +2289,17 @@ void Environment_FillScreen(GraphicsContext* gfxCtx, u8 red, u8 green, u8 blue, 
 }
 
 Color_RGB8 sSandstormPrimColors[] = {
-    { 210, 156, 85 },
-    { 255, 200, 100 },
-    { 225, 160, 50 },
-    { 105, 90, 40 },
+    { 210, 210, 210 },
+    { 255, 255, 255 },
+    { 225, 225, 225 },
+    { 105, 105, 105 },
 };
 
 Color_RGB8 sSandstormEnvColors[] = {
-    { 155, 106, 35 },
-    { 200, 150, 50 },
-    { 170, 110, 0 },
-    { 50, 40, 0 },
+    { 155, 155, 155 },
+    { 200, 200, 200 },
+    { 170, 170, 170 },
+    { 50, 50, 50 },
 };
 
 u16 previousPatchedSandstormScreenSize = 0;

--- a/soh/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
+++ b/soh/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
@@ -134,6 +134,10 @@ u8 WeatherTag_CheckEnableWeatherEffect(EnWeatherTag* this, PlayState* play, u8 a
     u8 ret = false;
     Player* player = GET_PLAYER(play);
 
+    if (LINK_IS_ADULT && gPlayState != NULL && gPlayState->sceneNum == SCENE_KAKARIKO_VILLAGE) {
+        return ret;
+    }
+
     if (Actor_WorldDistXZToActor(&player->actor, &this->actor) < WEATHER_TAG_RANGE100(this->actor.params)) {
         if ((play->envCtx.indoors != 0) || !gSkyboxBlendingEnabled ||
             (play->skyboxId != SKYBOX_NORMAL_SKY && play->envCtx.unk_1F == play->envCtx.unk_20)) {

--- a/soh/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
+++ b/soh/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
@@ -456,14 +456,14 @@ void EnWood02_Draw(Actor* thisx, PlayState* play) {
 
     if ((type == WOOD_TREE_OVAL_GREEN_SPAWNER) || (type == WOOD_TREE_OVAL_GREEN_SPAWNED) ||
         (type == WOOD_TREE_OVAL_GREEN) || (type == WOOD_LEAF_GREEN)) {
-        red = 50;
-        green = 170;
-        blue = 70;
+        red = 255;
+        green = 255;
+        blue = 255;
     } else if ((type == WOOD_TREE_OVAL_YELLOW_SPAWNER) || (type == WOOD_TREE_OVAL_YELLOW_SPAWNED) ||
                (type == WOOD_LEAF_YELLOW)) {
-        red = 180;
-        green = 155;
-        blue = 0;
+        red = 255;
+        green = 255;
+        blue = 255;
     } else {
         red = green = blue = 255;
     }


### PR DESCRIPTION
- Trees & Bushes colored white
- Sandstorm colored white
- Disable fog/environment color changes in adult kak
- Default alt assets to on
- Default main HUD buttons to white (the images are green)
- Paths colored

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/Caladius/Shipwright/actions/artifacts/1083028091.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/Caladius/Shipwright/actions/artifacts/1083028093.zip)
  - [soh-linux-performance.zip](https://nightly.link/Caladius/Shipwright/actions/artifacts/1083028094.zip)
  - [soh-mac.zip](https://nightly.link/Caladius/Shipwright/actions/artifacts/1083028097.zip)
  - [soh-switch.zip](https://nightly.link/Caladius/Shipwright/actions/artifacts/1083028099.zip)
  - [soh-wiiu.zip](https://nightly.link/Caladius/Shipwright/actions/artifacts/1083028101.zip)
  - [soh-windows.zip](https://nightly.link/Caladius/Shipwright/actions/artifacts/1083028103.zip)
<!--- section:artifacts:end -->