### PR TITLE
fix crown

### DIFF
--- a/soh/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
@@ -1452,7 +1452,7 @@ void BossGanondrof_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec
     if (((this->flyMode != GND_FLY_PAINTING) || (this->actionFunc == BossGanondrof_Intro)) && (limbIndex <= 25)) {
         Matrix_MultVec3f(&zeroVec, &this->bodyPartsPos[limbIndex - 1]);
     }
-    if (CVarGetInteger("gLetItSnow", 0)) {
+    if (CVarGetInteger("gLetItSnow", 0) && this->deathState == NOT_DEAD) {
         if (limbIndex == 15) {
             OPEN_DISPS(play->state.gfxCtx);
             Matrix_Push();


### PR DESCRIPTION
The crown would appear in the death cutscene after you have defeated phantom ganon and just hang over the blue warp at an odd angle in the air. This just adds a check to only draw when phantom ganon is alive