### PR TITLE
fix icon looping on linux

### DIFF
--- a/soh/soh/Enhancements/randomizer/Plandomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/Plandomizer.cpp
@@ -642,7 +642,10 @@ void PlandomizerDrawItemPopup(uint32_t index) {
               [](const auto& a, const auto& b) {
                 auto typeA = a.first.GetItemType();
                 auto typeB = b.first.GetItemType();
+                if (typeA != typeB){
                   return typeA < typeB;
+                }
+                return a.first.GetRandomizerGet() < b.first.GetRandomizerGet();
               });
         ImGui::SeparatorText("Resources");
         ImGui::BeginTable("Infinite Item Table", 7);


### PR DESCRIPTION
This fixes the icon looping on linux by using RandomiserGet as a secondary sort.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/Caladius/Shipwright/actions/artifacts/2190324955.zip)
  - [soh-windows.zip](https://nightly.link/Caladius/Shipwright/actions/artifacts/2190385412.zip)
  - [soh-linux.zip](https://nightly.link/Caladius/Shipwright/actions/artifacts/2190387875.zip)
  - [soh-mac.zip](https://nightly.link/Caladius/Shipwright/actions/artifacts/2190399904.zip)
<!--- section:artifacts:end -->